### PR TITLE
Cambio en método Connect para usar parámetro useSsl

### DIFF
--- a/Library/Pop3Client.cs
+++ b/Library/Pop3Client.cs
@@ -47,7 +47,7 @@ namespace Pop3
 
         public void Connect( string server, string userName, string password, bool useSsl )
         {
-            Connect( server, userName, password, 995, true );
+            Connect( server, userName, password, (useSsl ? 995 : 110), useSsl);
         }
         
         public void Connect( string server, string userName, string password, int portNumber, bool useSsl )


### PR DESCRIPTION
El segundo overload del método Connect asume que siempre el parámetro indica que se usa SSL cambie de la forma más simple posible.
