### PR TITLE
reading entire header including line breaks

### DIFF
--- a/LibraryCore/Pop3Message.cs
+++ b/LibraryCore/Pop3Message.cs
@@ -14,6 +14,7 @@ using System.Globalization;
 using System.Text;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 
 namespace Pop3
 {
@@ -228,7 +229,8 @@ namespace Pop3
 
             result = result.Remove( 0, ( index + headerName.Length + 2 ) ).Replace( "\r\n ", "" );
 
-            return result.Remove( result.IndexOf( '\r' ), ( result.Length - result.IndexOf( '\r' ) ) ).Replace( "\n", String.Empty ).Trim( );
+            int lastIndex = Regex.Match(result, @"^[A-Za-z\-]+\:.*$", RegexOptions.Multiline).Index;
+            return result.Remove( lastIndex, ( result.Length - lastIndex ) ).Trim( );
         }
 
         internal void ParseRawMessage( )


### PR DESCRIPTION
Hi Rodolfo!

I've noticed that some mail messages have line breaks in a single header field. this commit should take care of parsing the entire header field.

please merge and pack the nuget.