### PR TITLE
Correct UTF8 decoding via Decoder class

### DIFF
--- a/LibraryCore/IO/TcpClientNetworkOperations.cs
+++ b/LibraryCore/IO/TcpClientNetworkOperations.cs
@@ -86,8 +86,9 @@ namespace Pop3.IO
                 throw new InvalidOperationException( "The Network Stream is null" );
 
             byte[] data = new byte[ 1 ];
+            char[] chars = new char[ 1 ];
             StringBuilder sb = new StringBuilder( );
-            UTF8Encoding enc = new UTF8Encoding( );
+            Decoder decoder = Encoding.UTF8.GetDecoder( );
 
             while ( true )
             {
@@ -95,7 +96,11 @@ namespace Pop3.IO
                 if ( dataLength != 1 )
                     break;
 
-                sb.Append( enc.GetString( data, 0, 1 ) );
+                int charCount = decoder.GetChars( data, 0, 1, chars, 0 );
+                if ( charCount == 0 )
+                    continue;
+
+                sb.Append( chars[ 0 ] );
 
                 if ( data[ 0 ] == '\n' )
                     break;


### PR DESCRIPTION
When TcpClientNetworkOperations reads data from TcpClient it uses UTF8 encoding. Current implementation uses Encoding.GetString() method to transform byte to string. This approach contains potential bug because UTF8 chars can be represented by several bytes. In such case they would be treated wrong. In this pull request we use Decoder class which can keep track of "partial symbols" and decode them without error.

I've tested suggested fix only with GMail which doesn't seem to use UTF8 symbols (I've tested using emails in Russian) but I think it's safer to use this approach just to avoid possible nasty encoding bugs.